### PR TITLE
pass sanitizer instance into converter function, nested errors added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 /bin
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in input_sanitizer.gemspec
 gemspec
+
+group :test do
+  gem 'pry'
+end

--- a/lib/input_sanitizer/version.rb
+++ b/lib/input_sanitizer/version.rb
@@ -1,3 +1,3 @@
 module InputSanitizer
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Hi Base,

It looks like sanitizer doesn't collect errors from nested sanitizers. This pull req fixes that - errors from nested nodes are collected into sanitizer's error object when include_errors param is passed. Example in specs.
