### PR TITLE
Accept Procs in the `allow` option of StringCheck.

### DIFF
--- a/lib/input_sanitizer/v2/types.rb
+++ b/lib/input_sanitizer/v2/types.rb
@@ -40,7 +40,7 @@ module InputSanitizer::V2::Types
 
   class StringCheck
     def call(value, options = {})
-      if options[:allow] && !options[:allow].include?(value)
+      if options[:allow] && !allowed_value?(options[:allow], value)
         raise InputSanitizer::ValueNotAllowedError.new(value)
       elsif value.blank? && (options[:allow_blank] == false || options[:required] == true)
         raise InputSanitizer::BlankValueError
@@ -54,6 +54,16 @@ module InputSanitizer::V2::Types
           raise InputSanitizer::ValueError.new(value, options[:minimum], options[:maximum]) if options[:minimum] && string.length < options[:minimum]
           raise InputSanitizer::ValueError.new(value, options[:minimum], options[:maximum]) if options[:maximum] && string.length > options[:maximum]
         end
+      end
+    end
+
+    private
+
+    def allowed_value?(allowed_values, value)
+      if allowed_values.respond_to?(:call)
+        allowed_values.call.include?(value)
+      else
+        allowed_values.include?(value)
       end
     end
   end

--- a/spec/v2/payload_sanitizer_spec.rb
+++ b/spec/v2/payload_sanitizer_spec.rb
@@ -36,6 +36,10 @@ class BlankValuesPayloadSanitizer < InputSanitizer::V2::PayloadSanitizer
   url :non_blank_url, :allow_blank => false
 end
 
+class AllowProcPayloadSanitizer < InputSanitizer::V2::PayloadSanitizer
+  string :status, allow: -> { %w[current past] }
+end
+
 describe InputSanitizer::V2::PayloadSanitizer do
   let(:sanitizer) { TestedPayloadSanitizer.new(@params) }
   let(:cleaned) { sanitizer.cleaned }
@@ -113,6 +117,20 @@ describe InputSanitizer::V2::PayloadSanitizer do
       @params = { :status => 'current bad string' }
       sanitizer.should_not be_valid
       sanitizer.errors[0].field.should eq('/status')
+    end
+
+    context 'when a Proc is passed' do
+      let(:sanitizer) { AllowProcPayloadSanitizer.new(@params) }
+
+      it 'is valid when given an allowed string' do
+        @params = { status: 'current' }
+        sanitizer.should be_valid
+      end
+
+      it 'is invalid when given a disallowed string' do
+        @params = { status: 'invalid status' }
+        sanitizer.should_not be_valid
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation
The `allow` option currently accepts an enumerable object of allowed
values. In some cases it's not enough - for example, when it's supplied
with a database query. This works fine as long as no new records are
added to a table.

Now you can provide a `Proc`, `Lambda` or any other callable object which
returns an enumerable, so it can be called on each check.

### Example
```ruby
class Product < ActiveRecord:Base; end

string :code, allow: Product.pluck(:code)# It works until you add a new `Product`
string :code, allow: -> { Product.pluck(:code) } # It always works
```
