### PR TITLE
Use zendesk action

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: zendesk/checkout@v2
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: zendesk/setup-ruby@v1
       with:
         version: 2.6.x
 


### PR DESCRIPTION
Third party actions were disabled in zendesk organization. We need to use the copies inside of zendesk org