### PR TITLE
Migration onto GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,10 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
-        rvm: [2.0.0,2.1.0,2.2.0,2.5.8,jruby-19mode]
+        rvm: [2.1.9,2.2.10,2.5.8,jruby-head]
     steps:
     - uses: zendesk/checkout@v2
     - name: Set up Ruby
@@ -17,4 +17,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.rvm }}
     - name: Test ${{ matrix.rvm }}
-      run: bundle exec rspec spec
+      run: |
+        bundle install
+        bundle exec rspec spec

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         rvm: [2.0.0,2.1.0,2.2.0,2.5.8,jruby-19mode]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rvm: [2.0.0,2.1.0,2.2.0,2.5.8,jruby-19mode]
+    steps:
+    - uses: zendesk/checkout@v2
+    - name: Set up Ruby
+      uses: zendesk/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.rvm }}
+    - name: Test ${{ matrix.rvm }}
+      run: bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-script: bundle exec rspec spec
-rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.5.8
-  - jruby-19mode

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# InputSanitizer [![Build Status](https://secure.travis-ci.org/futuresimple/input_sanitizer.png?branch=master)](http://travis-ci.org/futuresimple/input_sanitizer)
+# InputSanitizer
+![CI](https://github.com/zendesk/input_sanitizer/workflows/CI/badge.svg)
 
 Gem to sanitize hash of incoming data
 


### PR DESCRIPTION
This PR replaces Travis CI with Github Actions.

FYI - The setup-ruby action doesn't support the following versions  2.0.0,2.1.0,2.2.0,2.5.8 and jruby-19mode. I have updated them to 2.1.9,2.2.10,2.5.8 and jruby-head. Let me know if this is an issue for you.
